### PR TITLE
Fix the cache option

### DIFF
--- a/lib/express-stylus-middleware.js
+++ b/lib/express-stylus-middleware.js
@@ -15,6 +15,7 @@ var fs = require('fs'),
   stylus = require('stylus'),
   autoprefixer = require('autoprefixer-stylus');
 
+var cache = {};
 
 module.exports = function(root, options) {
     options = options || {};


### PR DESCRIPTION
The middleware failed to work If cache option was set to be true. It throw `ReferenceError: cache is not defined.`